### PR TITLE
Skeleton of STM32F4 example based on STM32CubeF4 suite

### DIFF
--- a/examples/stm32f4/CMakeLists.txt
+++ b/examples/stm32f4/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_TOOLCHAIN_FILE toolchain-arm-gcc.cmake)
+
+# Find, where pico-sdk is installed. Is the path provided on commandline?
+if (NOT STM_CUBE_PATH)
+    # Do we have pico-sdk checked out locally?
+    if (IS_DIRECTORY ${CMAKE_SOURCE_DIR}/STMCube32F4)
+        set(PICO_SDK_PATH ${CMAKE_SOURCE_DIR}/STMCube32F4)
+    else()
+        message(FATAL_ERROR "Path to STM32CubeF4 not defined! Please, define use -DSTM_CUBE_PATH=<path_to_stm_cube> to define where Raspberry Pi Pico SDK has been downloaded.\n\nAlternatively run git clone https://github.com/STMicroelectronics/STM32CubeF4 in source directory of this example.")
+    endif()
+endif()
+
+# FindCMSIS will generate some CMSIS-related headers into build directory
+include_directories(${CMAKE_BINARY_DIR})
+
+# To get access to FindCMSIS
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+
+# Path to kernel sources
+set(OS_SRCS_ROOT ${CMAKE_SOURCE_DIR}/../../src)
+
+# To be able to include kernel headers
+include_directories(${OS_SRCS_ROOT})
+
+
+set(CMSIS_ROOT ${STM_CUBE_PATH}/Drivers/CMSIS/)
+set(DEVICE stm32f410cx)
+set(CMSIS_STARTUP_FILTER gcc)
+set(SYSTEM_SOURCE ${STM_CUBE_PATH}/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c)
+set(CMSIS_LINKER_FILE ${STM_CUBE_PATH}/Projects/STM32F410xx-Nucleo/Templates/SW4STM32/STM32F410Cx_Nucleo/STM32F410CBUx_FLASH.ld)
+
+include(FindCMSIS)
+
+project(bare-rtos-example C CXX ASM)
+
+add_definitions(-Wall -Wextra)
+add_definitions(-DSTM32F410Cx)
+add_definitions(-mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fomit-frame-pointer)
+add_link_options(-mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16)
+add_link_options(-T${CMSIS_LINKER_FILE})
+add_executable(bare-rtos ${OS_SRCS_ROOT}/kernel/kernel.c main.c)
+target_link_libraries(bare-rtos cmsis_interface cmsis_startup)
+#pico_add_extra_outputs(bare-rtos)
+
+#add_executable(bare-rtos-cpp ${OS_SRCS_ROOT}/kernel/kernel.c main.c)
+#target_link_libraries(bare-rtos-cpp pico_stdlib cmsis_interface cmsis_core)
+#pico_add_extra_outputs(bare-rtos-cpp)

--- a/examples/stm32f4/main.c
+++ b/examples/stm32f4/main.c
@@ -1,0 +1,88 @@
+#include <kernel/api.h>
+#include <RTE_Components.h>
+#include CMSIS_device_header
+#include <stdint.h>
+
+#define THREADS_MAX         16
+
+uint8_t kernel_threads_count() { return THREADS_MAX; }
+
+struct OS_thread_t os_threads[THREADS_MAX];
+
+uint32_t thread1_stack[256];
+uint32_t thread2_stack[256];
+
+/// Our example systick handler 
+// This implements round robin scheduler. It goes around thread table
+// starting with next thread after one currently running. It searches
+// for whatever thread which is marked as ready. It then schedules this 
+// thread for execution and schedules PendSV interrupt handler to be called.
+void SysTick_Handler()
+{
+    Thread_ID_t current_thread = os_get_current_thread();
+    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    do {
+        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        {
+            os_schedule_context_switch(next_thread);
+            return;
+        }
+        next_thread = (next_thread + 1) % kernel_threads_count();
+    } while (next_thread != current_thread);
+}
+
+// Example thread #1. It blindly activates our RPi Pico only LED
+void thread1_main(void * data)
+{
+    (void) data;
+
+    while (1) {
+    }
+}
+
+// Example thread #2. It blindly deactivated our RPi Pico only LED
+void thread2_main(void * data)
+{
+    (void) data;
+    while (1) {
+    }
+}
+
+/// Systic setup routine.
+// This routine takes systick interval in milliseconds and generates
+// systick reload value. If this is too large for current CPU speed
+// then it is trimmed to largest possible value. Next, systick is
+// initialized using this value.
+// Next, we set PendSV priority to 255 (actually 192) so it is one of
+// the lowerst-priority interrupts and never interrupts anything else 
+// than regular threads.
+void kernel_tick_setup(int interval_ms)
+{
+    const uint32_t systick_max = (1 << 24) - 1;
+    uint32_t systick_val = (SystemCoreClock / 1000) * interval_ms;
+    if (systick_val > systick_max)
+        systick_val = systick_max;
+    // It seems that some implementations make SysTick of lower priority than other interrupts
+    // Here we need that PendSV has absolutely the lowest priority, so it will never interrupt 
+    // any other ISR
+    NVIC_SetPriority(PendSV_IRQn, 255);
+    SysTick_Config(systick_val);
+}
+
+/// Firmware entrypoint
+// Here we set generic GPIO properties, create two threads and start the RTOS
+int main(void)
+{
+    // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
+    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
+    (void) thr2;
+    
+    // Setup systick
+    kernel_tick_setup(500);
+
+    // Start up the kernel
+    os_start(thr1);
+
+    while (1);    
+}

--- a/examples/stm32f4/toolchain-arm-gcc.cmake
+++ b/examples/stm32f4/toolchain-arm-gcc.cmake
@@ -1,0 +1,65 @@
+# Copyright (C) 2021 Eduard Drusa
+# SPDX-License-Identifier: MPL-2.0
+
+if (NOT EXISTS CACHE{GCC_EXE})
+	find_program(GCC_EXE arm-none-eabi-gcc
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM cross-compiler toolchain location")
+endif()
+
+if (NOT EXISTS CACHE{LD_EXE})
+	find_program(LD_EXE arm-none-eabi-ld
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM cross-compiler linker location")
+endif()
+
+if (NOT EXISTS CACHE{OBJCOPY_EXE})
+	find_program(OBJCOPY_EXE arm-none-eabi-objcopy
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM objcopy location")
+endif()
+
+if (NOT EXISTS CACHE{AR_EXE})
+	find_program(AR_EXE arm-none-eabi-gcc-ar
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM archiver location")
+endif()
+
+if (NOT EXISTS CACHE{RANLIB_EXE})
+	find_program(RANLIB_EXE arm-none-eabi-gcc-ranlib
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM ranlib location")
+endif()
+
+if ("${GCC_EXE}" STREQUAL "GCC_EXE-NOTFOUND")
+	message(FATAL_ERROR "Unable to find arm-none-eabi GCC toolchain! Either place it in one of following locations:\n/opt/arm/bin\n/usr/bin\n/usr/local/bin\nor provide its path in CROSS_GCC_PATH environment variable!")
+endif()
+
+add_link_options(--specs=nosys.specs)
+add_definitions(-fuse-linker-plugin)
+
+set(CMAKE_C_COMPILER "${GCC_EXE}")
+set(CMAKE_ASM_COMPILER "${GCC_EXE}")
+set(CMAKE_C_LINKER "${LD_EXE}")
+set(CMAKE_AR "${AR_EXE}")
+set(CMAKE_RANLIB "${RANLIB_EXE}")
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_PROCESSOR "arm")
+set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_EXECUTABLE_SUFFIX_C ".elf")
+set(CMAKE_EXE_LINKER_FLAGS "-Wall -flto")# --plugin=/opt/arm-none-eabi/libexec/gcc/avr/4.9.3/liblto_plugin.so")


### PR DESCRIPTION
This adds STM32F4 example based on random MCU out of F4 range. Code is built against STM32CubeF4 repo without any modifications. Code builds, but was not tested to be actually running.