### PR TITLE
Improve FindCMSIS.cmake, add nRF5 SDK example

### DIFF
--- a/cmake/FindCMSIS.cmake
+++ b/cmake/FindCMSIS.cmake
@@ -1,6 +1,5 @@
 message(STATUS "CMSIS root is: ${CMSIS_ROOT}")
 message(STATUS "DEVICE is: ${DEVICE}")
-message(STATUS "LIST dir is: ${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Find CMSIS components one by one
 # These files shall exist in any CMSIS-compatible SDK, find them
@@ -9,13 +8,24 @@ file(GLOB_RECURSE SYSTEM_INCLUDE ${CMSIS_ROOT}/*/system_${DEVICE}.h)
 file(GLOB_RECURSE CORES_INCLUDE ${CMSIS_ROOT}/*/core_cm*.h)
 
 # Search for system source if it was not provided manually
-if (SYSTEM_SOURCE STREQUAL "")
-    file(GLOB_RECURSE SYSTEM_SOURCE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMSIS_ROOT}/*/system_${DEVICE}.s)
+if ("${SYSTEM_SOURCE}" STREQUAL "")
+    file(GLOB_RECURSE SYSTEM_SOURCE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} 
+        ${CMSIS_ROOT}/*/system_${DEVICE}.c
+        ${CMSIS_ROOT}/*/system_${DEVICE}.s
+    )
+else()
+    message(STATUS "Skipping system source search(${SYSTEM_SOURCE})...")
 endif()
 
 # Search for startup source if it was not provided manually
-if (NOT STARTUP_SOURCE STREQUAL "")
-    file(GLOB_RECURSE STARTUP_SOURCE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMSIS_ROOT}/*/startup_${DEVICE}.s)
+if ("${STARTUP_SOURCE}" STREQUAL "")
+    file(GLOB_RECURSE STARTUP_SOURCE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} 
+        ${CMSIS_ROOT}/*/*startup_${DEVICE}.s
+        ${CMSIS_ROOT}/*/*startup_${DEVICE}.S
+        ${CMSIS_ROOT}/*/*startup_${DEVICE}.c
+    )
+else()
+    message(STATUS "Skipping startup source search (${STARTUP_SOURCE})...")
 endif()
 
 message(STATUS "Device include: ${DEVICE_INCLUDE}")
@@ -26,12 +36,18 @@ message(STATUS "Cortex-M includes: ${CORES_INCLUDE}")
 if (CMSIS_SYSTEM_FILTER)
     list(FILTER SYSTEM_SOURCE INCLUDE REGEX ${CMSIS_SYSTEM_FILTER})
 endif()
+
+if (CMSIS_STARTUP_FILTER)
+    list(FILTER STARTUP_SOURCE INCLUDE REGEX ${CMSIS_STARTUP_FILTER})
+endif()
+
 message(STATUS "System source: ${SYSTEM_SOURCE}")
 
 # Some SDKs provide startup files for multiple toolchains, let them to be filtered
 if (CMSIS_STARTUP_FILTER)
-    list(FILTER STARTUP_SOURCE INCLUDE REGEX ${CMSIS_STARTUP_FILTER})
+        list(FILTER STARTUP_SOURCE INCLUDE REGEX ${CMSIS_STARTUP_FILTER})
 endif()
+
 message(STATUS "Startup source: ${STARTUP_SOURCE}")
 
 # Extract paths to each of headers to compose CMSIS include directories 
@@ -41,6 +57,8 @@ foreach(FILE IN LISTS DEVICE_INCLUDE SYSTEM_INCLUDE CORES_INCLUDE)
         list(APPEND INCLUDE_DIRS "${INC_DIR}")
     endif()
 endforeach()
+
+get_filename_component(LINK_DIR "${CMSIS_LINKER_FILE}" DIRECTORY)
 
 # Check that linker file has been specified
 if (NOT CMSIS_LINKER_FILE)
@@ -53,21 +71,16 @@ if (NOT EXISTS ${CMSIS_LINKER_FILE})
 endif()
 
 get_filename_component(CMSIS_LINKER_FILENAME "${CMSIS_LINKER_FILE}" NAME)
-# Copy linker file into binary directory, so we can touch it
-file(COPY_FILE ${CMSIS_LINKER_FILE} ${CMAKE_BINARY_DIR}/gen.${DEVICE}.ld)
 
 # Generate generic include file stub
 # This shall normally be provided by the SDK, but not all of them actually
 # do this. This way, we can generate RTE_Components.h into build directory.
-file(WRITE ${CMAKE_BINARY_DIR}/cmsis_conf.h 
+file(WRITE ${CMAKE_BINARY_DIR}/RTE_Components.h 
     "#pragma once
 "
     "#define CMSIS_device_header \"${DEVICE}.h\"
 "
     )
-
-# Copy file to well known name
-file(COPY_FILE ${CMAKE_BINARY_DIR}/cmsis_conf.h ${CMAKE_BINARY_DIR}/RTE_Components.h)
 
 # Create target, which if linked against, will provide CMSIS include directories
 set(CMSIS_SRCS ${SYSTEM_SOURCE} ${STARTUP_SOURCE})
@@ -81,9 +94,10 @@ set_property(TARGET cmsis_interface
 
 # Add startup library, but only if there are any source for it
 if ((NOT "${STARTUP_SOURCE}" STREQUAL "") OR (NOT "${SYSTEM_SOURCE}" STREQUAL ""))
-    add_library(cmsis_startup STATIC ${STARTUP_SOURCE} ${SYSTEM_SOURCE})
+    add_library(cmsis_startup STATIC EXCLUDE_FROM_ALL ${STARTUP_SOURCE} ${SYSTEM_SOURCE})
     set_property(TARGET cmsis_startup
         PROPERTY
         INTERFACE_LINK_OPTIONS "-T${CMSIS_LINKER_FILE}")
+    target_link_directories(cmsis_startup INTERFACE ${LINK_DIR})
     target_link_libraries(cmsis_startup cmsis_interface)
 endif()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,102 @@
+Helper CMake module to find CMSIS in your Cortex-M SDK
+======================================================
+
+This script will try to find all necessary components of CMSIS inside
+your SDK distribution. There are couple components we need:
+ * device header file, usually named <device>.h
+ * system header file, usually named system_<device>.h
+ * system source file, usually named system_<device>.c 
+ * startup source file, usually named startup_<device>.c / S / s
+ * Cortex-M header files, usually named core_cm<number>.h
+
+Then we need to know which linker file is going to be used. This has to 
+be determined by the user.
+
+This helper script will provide two libraries:
+
+cmsis_interface
+---------------
+This one provides include paths to all detected header files. Simply link 
+it to your binary and it will have all the include paths to CMSIS headers 
+available. You can include all files without actually bothering to locate
+them.
+
+cmsis_startup
+-------------
+This one provides actual startup and system code. If you link it to your
+binary, startup and system code will be linked. The reason, why this is 
+separated from interface library is, that a) some SDKs, such as pico-sdk
+have some stuff in system library dependant on HAL headers. So you have
+to link the whole sdk library. b) you may want to use your own startup
+code.
+
+Aside from two targets, this code also creates two files. CMSIS standard
+requires a file named RTE_Components.h be created somewhere in the include
+path. This file defines CMSIS_device_header, which points to actual location
+of CMSIS device header (the one <device>.h). You can simply include 
+RTE_Components.h and then have line
+
+#include CMSIS_device_header
+
+And device header for the used device will automatically be linked. this
+makes the code a bit more portable. This file is created in the root of
+build directory, so you can (shall) add include_directories(${CMAKE_BINARY_DIR})
+to your top-level CMakeLists.txt to be able to use it.
+
+Usage
+=====
+
+To use this module, first define a few variables:
+
+CMSIS_ROOT
+----------
+The root directory of your SDK, if too large, some of subdirectories which contains
+all the CMSIS components.
+
+DEVICE
+------
+The name of your MCU. It is case sensitive.
+
+CMSIS_LINKER_FILE
+-----------------
+Path to the linker file.
+
+Then simply include FindCMSIS.cmake. It will try to find all the components needed
+and creates two targets for further use.
+
+Advanced use
+============
+
+Many of SDKs have some deviations and not all features can be detected automatically.
+For such cases, there are advanced options. You can define any of the following variables
+to leverage these options:
+
+STARTUP_SOURCE
+--------------
+Define this variable in order to hardcode filename of startup source for given MCU.
+This is the file usually named startup_<device>.c, .S or .s. In rare cases, the file 
+does not follow this naming pattern and cannot be found automatically. Automatic detection
+will be skipped for this file, if variable is set prior including FindCMSIS.
+
+SYSTEM_SOURCE
+-------------
+Define this variable in order to hardcode filename of system source for given MCU.
+This is the file usually named startup_<device>.c but sometimes this file is shared between
+multiple MCUs and the device part does not match device name exactly, or entirely. In such
+cases you can enforce the file name here. Automatic detection will be skipped for this
+file, if variable is set before including FindCMSIS.
+
+CMSIS_SYSTEM_FILTER
+-------------------
+Sometimes it happens that SDK supports multiple compilers and there are multiple copies
+of certain files. You only want to include some of them. You can set this variable to 
+contain regex, which will be used to filter system source files to only contain those
+relevant for your toolchain.
+
+CMSIS_STARTUP_FILTER
+--------------------
+Quite often, startup files are duplicated and there are multiple copies, one for each 
+toolchain, which is supported. You can use this variable to filter out only files 
+relevant for your toolchain. Set it to any non-empty regex to filter out only files
+relevant to you.
+

--- a/examples/nrf52-pinetime/CMakeLists.txt
+++ b/examples/nrf52-pinetime/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_TOOLCHAIN_FILE toolchain-arm-gcc.cmake)
+
+# Find, where pico-sdk is installed. Is the path provided on commandline?
+if (NOT NRF_SDK_PATH)
+    # Do we have pico-sdk checked out locally?
+    message(FATAL_ERROR "Path to nRF5 SDK not defined! Please, define use -DNRF_SDK_PATH=<path_to_stm_cube> to define where it is installed.")
+endif()
+
+# FindCMSIS will generate some CMSIS-related headers into build directory
+include_directories(${CMAKE_BINARY_DIR})
+
+# To get access to FindCMSIS
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+
+# Path to kernel sources
+set(OS_SRCS_ROOT ${CMAKE_SOURCE_DIR}/../../src)
+
+# To be able to include kernel headers
+include_directories(${OS_SRCS_ROOT})
+
+# Vast majority of CMSIS lives under /modules/nrfx/mdk, but Cortex headers
+# are elsewhere, search the whole nRF SDK here
+set(CMSIS_ROOT ${NRF_SDK_PATH})
+
+# nrf52832 is an alias to nrf52 
+set(DEVICE nrf52)
+
+# nRF SDK has startups for multiple toolchains, filter out for gcc
+set(CMSIS_STARTUP_FILTER gcc)
+
+# We will use provided linker script directly
+set(CMSIS_LINKER_FILE ${NRF_SDK_PATH}/modules/nrfx/mdk/nrf52832_xxaa.ld)
+
+# We have to specify these manually -fomit-frame-pointer is required for
+# thread swticher to be able to touch r7
+add_definitions(-mcpu=cortex-m4 -mthumb -mfloat-abi=hard -fomit-frame-pointer)
+
+# Link options have to match compile options for these, so the compiler
+# can choose the correct multi-lib variant
+add_link_options(-mcpu=cortex-m4 -mthumb -mfloat-abi=hard)
+
+# Find CMSIS here
+include(FindCMSIS)
+
+# Define project, initialize the compiler
+project(bare-rtos-example C CXX ASM)
+
+# To bash all the warnings
+add_definitions(-Wall -Wextra)
+
+# NRF SDK wants this
+add_definitions(-DNRF52)
+
+# Define our firmware
+add_executable(bare-rtos ${OS_SRCS_ROOT}/kernel/kernel.c main.c)
+
+# Link it with interface library and with startup library
+target_link_libraries(bare-rtos cmsis_interface cmsis_startup)
+

--- a/examples/nrf52-pinetime/main.c
+++ b/examples/nrf52-pinetime/main.c
@@ -1,0 +1,87 @@
+#include <kernel/api.h>
+#include <RTE_Components.h>
+#include CMSIS_device_header
+#include <stdint.h>
+
+#define THREADS_MAX         16
+
+uint8_t kernel_threads_count() { return THREADS_MAX; }
+
+struct OS_thread_t os_threads[THREADS_MAX];
+
+uint32_t thread1_stack[256];
+uint32_t thread2_stack[256];
+
+/// Our example systick handler 
+// This implements round robin scheduler. It goes around thread table
+// starting with next thread after one currently running. It searches
+// for whatever thread which is marked as ready. It then schedules this 
+// thread for execution and schedules PendSV interrupt handler to be called.
+void SysTick_Handler()
+{
+    Thread_ID_t current_thread = os_get_current_thread();
+    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    do {
+        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        {
+            os_schedule_context_switch(next_thread);
+            return;
+        }
+        next_thread = (next_thread + 1) % kernel_threads_count();
+    } while (next_thread != current_thread);
+}
+
+// Example thread #1. It blindly activates our RPi Pico only LED
+void thread1_main(void * data)
+{
+    (void) data;
+
+    while (1) {
+    }
+}
+
+// Example thread #2. It blindly deactivated our RPi Pico only LED
+void thread2_main(void * data)
+{
+    (void) data;
+    while (1) {
+    }
+}
+
+/// Systic setup routine.
+// This routine takes systick interval in milliseconds and generates
+// systick reload value. If this is too large for current CPU speed
+// then it is trimmed to largest possible value. Next, systick is
+// initialized using this value.
+// Next, we set PendSV priority to 255 (actually 192) so it is one of
+// the lowerst-priority interrupts and never interrupts anything else 
+// than regular threads.
+void kernel_tick_setup(int interval_ms)
+{
+    const uint32_t systick_max = (1 << 24) - 1;
+    uint32_t systick_val = (SystemCoreClock / 1000) * interval_ms;
+    if (systick_val > systick_max)
+        systick_val = systick_max;
+    // It seems that some implementations make SysTick of lower priority than other interrupts
+    // Here we need that PendSV has absolutely the lowest priority, so it will never interrupt 
+    // any other ISR
+    NVIC_SetPriority(PendSV_IRQn, 255);
+    SysTick_Config(systick_val);
+}
+
+/// Firmware entrypoint
+int main(void)
+{
+    // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
+    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
+    (void) thr2;
+    
+    // Setup systick
+    kernel_tick_setup(500);
+
+    // Start up the kernel
+    os_start(thr1);
+
+    while (1);    
+}

--- a/examples/nrf52-pinetime/toolchain-arm-gcc.cmake
+++ b/examples/nrf52-pinetime/toolchain-arm-gcc.cmake
@@ -1,0 +1,65 @@
+# Copyright (C) 2021 Eduard Drusa
+# SPDX-License-Identifier: MPL-2.0
+
+if (NOT EXISTS CACHE{GCC_EXE})
+	find_program(GCC_EXE arm-none-eabi-gcc
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM cross-compiler toolchain location")
+endif()
+
+if (NOT EXISTS CACHE{LD_EXE})
+	find_program(LD_EXE arm-none-eabi-ld
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM cross-compiler linker location")
+endif()
+
+if (NOT EXISTS CACHE{OBJCOPY_EXE})
+	find_program(OBJCOPY_EXE arm-none-eabi-objcopy
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM objcopy location")
+endif()
+
+if (NOT EXISTS CACHE{AR_EXE})
+	find_program(AR_EXE arm-none-eabi-gcc-ar
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM archiver location")
+endif()
+
+if (NOT EXISTS CACHE{RANLIB_EXE})
+	find_program(RANLIB_EXE arm-none-eabi-gcc-ranlib
+		PATHS
+		/opt/arm/bin
+		/opt/arm-none-eabi/bin
+		ENV CROSS_GCC_PATH
+		DOC "ARM ranlib location")
+endif()
+
+if ("${GCC_EXE}" STREQUAL "GCC_EXE-NOTFOUND")
+	message(FATAL_ERROR "Unable to find arm-none-eabi GCC toolchain! Either place it in one of following locations:\n/opt/arm/bin\n/usr/bin\n/usr/local/bin\nor provide its path in CROSS_GCC_PATH environment variable!")
+endif()
+
+add_link_options(--specs=nosys.specs)
+add_definitions(-fuse-linker-plugin)
+
+set(CMAKE_C_COMPILER "${GCC_EXE}")
+set(CMAKE_ASM_COMPILER "${GCC_EXE}")
+set(CMAKE_C_LINKER "${LD_EXE}")
+set(CMAKE_AR "${AR_EXE}")
+set(CMAKE_RANLIB "${RANLIB_EXE}")
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_PROCESSOR "arm")
+set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_EXECUTABLE_SUFFIX_C ".elf")
+set(CMAKE_EXE_LINKER_FLAGS "-Wall -flto")# --plugin=/opt/arm-none-eabi/libexec/gcc/avr/4.9.3/liblto_plugin.so")


### PR DESCRIPTION
Clean up FindCMSIS a bit. Remove routine, which copies linker script into binary directory. This won't work if linker script actually includes another scripts (such as in case of nRF5 SDK). User can do that manually if really needed.

Remove creation of cmsis_conf.h. Only create RTE_Components.h. It makes no sense to create additional "standard" if there is one well known name for that file.

Make cmsis_startup library excluded from ALL. This way it is only built if linked to some binary. This fixes rp2040 support. There you have to use whole pico-sdk to get the startup.

Obtain directory in which linker script exists and publish it as a link directory. This way, if there are nested linker scripts, the whole stuff will still be working. You have to include cmsis_startup in order for this to be working.

Add nRF5 SDK-based example.