### PR TITLE
Example of C++20 module use

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,9 @@ As of now, there are examples of how to build nano RTOS on top of following SDKs
    SDK. You cannot link just cmsis_startup library due to the way how external FLASH
    is supported. Also, as this SDK is built on top of CMake, you basically have to 
    use CMake to build your project.
+ * C++20 module example - This example is also based on RP2040 platform (which actually
+   doesn't matter) and shows how to use the C++20 module. You need fairly modern compiler
+   to be able to build this example.
 
 All examples are accompanied by CMakeLists.txt as of now. These files have toolchain
 files bundled to add support for arm-gcc cross compiler. These files assume that

--- a/examples/cpp-rp2040/CMakeLists.txt
+++ b/examples/cpp-rp2040/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Find, where pico-sdk is installed. Is the path provided on commandline?
+if (NOT PICO_SDK_PATH)
+    # Do we have pico-sdk checked out locally?
+    if (IS_DIRECTORY ${CMAKE_SOURCE_DIR}/pico-sdk)
+        set(PICO_SDK_PATH ${CMAKE_SOURCE_DIR}/pico-sdk)
+    else()
+        message(FATAL_ERROR "Path to pico-sdk not defined! Please, define use -DPICO_SDK_PATH=<path_to_pico_sdk> to define where Raspberry Pi Pico SDK has been downloaded.\n\nAlternatively run git clone https://github.com/raspberrypi/pico-sdk in source directory of this example.")
+    endif()
+endif()
+
+include_directories(${PICO_SDK_PATH})
+
+# FindCMSIS will generate some CMSIS-related headers into build directory
+include_directories(${CMAKE_BINARY_DIR})
+
+# To get access to pico-sdk stuff without actually copying it over
+list(APPEND CMAKE_MODULE_PATH "${PICO_SDK_PATH}/external")
+
+# To get access to FindCMSIS
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+
+# Include pico-sdk
+include(pico_sdk_import)
+
+# Path to kernel sources
+set(OS_SRCS_ROOT ${CMAKE_SOURCE_DIR}/../../src)
+
+# To be able to include kernel headers
+include_directories(${OS_SRCS_ROOT})
+
+
+set(CMSIS_ROOT ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS)
+set(DEVICE RP2040)
+set(CMSIS_LINKER_FILE ${PICO_SDK_PATH}/src/rp2_common/pico_standard_link/memmap_default.ld)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmodules-ts")
+set(CMAKE_CXX_FLAGS_Debug "${CMAKE_CXX_FLAGS_Debug} -ggdb3")
+
+
+include(FindCMSIS)
+
+project(bare-rtos-example C CXX ASM)
+
+pico_sdk_init()
+add_definitions(-Wall -Wextra)
+
+add_executable(bare-rtos ${OS_SRCS_ROOT}/kernel/kernel.cpp main.cpp)
+target_link_libraries(bare-rtos pico_stdlib cmsis_interface cmsis_core)
+pico_add_extra_outputs(bare-rtos)
+

--- a/examples/cpp-rp2040/main.cpp
+++ b/examples/cpp-rp2040/main.cpp
@@ -1,0 +1,84 @@
+#include <pico/stdlib.h>
+#include <RTE_Components.h>
+#include CMSIS_device_header
+#include <stdint.h>
+
+import bare_rtos;
+
+uint32_t thread1_stack[256];
+uint32_t thread2_stack[256];
+
+const uint32_t LED_PIN = PICO_DEFAULT_LED_PIN;
+
+/// Our example systick handler 
+// This implements round robin scheduler. It goes around thread table
+// starting with next thread after one currently running. It searches
+// for whatever thread which is marked as ready. It then schedules this 
+// thread for execution and schedules PendSV interrupt handler to be called.
+extern"C" void SysTick_Handler()
+{
+    scheduler.schedule();
+}
+
+// Example thread #1. It blindly activates our RPi Pico only LED
+void thread1_main(void * data)
+{
+    (void) data;
+
+    while (1) {
+        gpio_put(LED_PIN, 1);
+    }
+}
+
+// Example thread #2. It blindly deactivated our RPi Pico only LED
+void thread2_main(void * data)
+{
+    (void) data;
+    while (1) {
+        gpio_put(LED_PIN, 0);
+    }
+}
+
+/// Systic setup routine.
+// This routine takes systick interval in milliseconds and generates
+// systick reload value. If this is too large for current CPU speed
+// then it is trimmed to largest possible value. Next, systick is
+// initialized using this value.
+// Next, we set PendSV priority to 255 (actually 192) so it is one of
+// the lowerst-priority interrupts and never interrupts anything else 
+// than regular threads.
+void kernel_tick_setup(int interval_ms)
+{
+    const uint32_t systick_max = (1 << 24) - 1;
+    uint32_t systick_val = (SystemCoreClock / 1000) * interval_ms;
+    if (systick_val > systick_max)
+        systick_val = systick_max;
+    // It seems that some implementations make SysTick of lower priority than other interrupts
+    // Here we need that PendSV has absolutely the lowest priority, so it will never interrupt 
+    // any other ISR
+    NVIC_SetPriority(PendSV_IRQn, 255);
+    SysTick_Config(systick_val);
+}
+
+/// Firmware entrypoint
+// Here we set generic GPIO properties, create two threads and start the RTOS
+int main(void)
+{
+    // RPi Pico LED configuration - make GPIO an output
+    gpio_init(LED_PIN);
+    gpio_set_dir(LED_PIN, GPIO_OUT);
+
+    // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
+    Thread thr1(thread1_main, thread1_stack, sizeof(thread1_stack), (void *) 0);
+    Thread thr2(thread2_main, thread2_stack, sizeof(thread2_stack), (void *) 0);
+    
+    scheduler.append(thr1);
+    scheduler.append(thr2);
+    // Setup systick
+    kernel_tick_setup(500);
+
+    // Start up the kernel
+    scheduler.start();
+
+    while (1);    
+}


### PR DESCRIPTION
Added example of C++20 module use. This example uses RP2040 as target platform. CMake files provided.