### PR TITLE
Feature/c api array to list

### DIFF
--- a/examples/nrf52-pinetime/main.c
+++ b/examples/nrf52-pinetime/main.c
@@ -3,14 +3,12 @@
 #include CMSIS_device_header
 #include <stdint.h>
 
-#define THREADS_MAX         16
+uint8_t thread1_stack[256];
+uint8_t thread2_stack[256];
 
-uint8_t kernel_threads_count() { return THREADS_MAX; }
+#define THREADS_MAX     2
 
-struct OS_thread_t os_threads[THREADS_MAX];
-
-uint32_t thread1_stack[256];
-uint32_t thread2_stack[256];
+struct OS_Thread_t threads[THREADS_MAX];
 
 /// Our example systick handler 
 // This implements round robin scheduler. It goes around thread table
@@ -19,15 +17,22 @@ uint32_t thread2_stack[256];
 // thread for execution and schedules PendSV interrupt handler to be called.
 void SysTick_Handler()
 {
-    Thread_ID_t current_thread = os_get_current_thread();
-    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    struct OS_Thread_t * current_thread = os_get_current_thread();
+    struct OS_Thread_t * next_thread = (current_thread + 1);
+
+    if (next_thread >= &threads[THREADS_MAX])
+        next_thread = &threads[0];
+
     do {
-        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        if (next_thread->state == THREAD_STATE_READY)
         {
             os_schedule_context_switch(next_thread);
             return;
         }
-        next_thread = (next_thread + 1) % kernel_threads_count();
+        next_thread = (next_thread + 1);
+        if (next_thread >= &threads[THREADS_MAX])
+            next_thread = &threads[0];
+
     } while (next_thread != current_thread);
 }
 
@@ -73,15 +78,14 @@ void kernel_tick_setup(int interval_ms)
 int main(void)
 {
     // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
-    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
-    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
-    (void) thr2;
+    os_thread_create(&threads[0], thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    os_thread_create(&threads[1], thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
     
     // Setup systick
     kernel_tick_setup(500);
 
     // Start up the kernel
-    os_start(thr1);
+    os_start(&threads[0]);
 
     while (1);    
 }

--- a/examples/rp2040/CMakeLists.txt
+++ b/examples/rp2040/CMakeLists.txt
@@ -34,6 +34,8 @@ include_directories(${OS_SRCS_ROOT})
 set(CMSIS_ROOT ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS)
 set(DEVICE RP2040)
 set(CMSIS_LINKER_FILE ${PICO_SDK_PATH}/src/rp2_common/pico_standard_link/memmap_default.ld)
+set(CMAKE_C_FLAGS_Debug "${CMAKE_C_FLAGS_Debug} -ggdb3")
+set(CMAKE_CXX_FLAGS_Debug "${CMAKE_C_FLAGS_Debug} -ggdb3")
 
 include(FindCMSIS)
 

--- a/examples/rp2040/main.c
+++ b/examples/rp2040/main.c
@@ -4,16 +4,14 @@
 #include CMSIS_device_header
 #include <stdint.h>
 
-#define THREADS_MAX         16
-
-uint8_t kernel_threads_count() { return THREADS_MAX; }
-
-struct OS_thread_t os_threads[THREADS_MAX];
-
-uint32_t thread1_stack[256];
-uint32_t thread2_stack[256];
-
 const uint32_t LED_PIN = PICO_DEFAULT_LED_PIN;
+
+uint8_t thread1_stack[256];
+uint8_t thread2_stack[256];
+
+#define THREADS_MAX     2
+
+struct OS_Thread_t threads[THREADS_MAX];
 
 /// Our example systick handler 
 // This implements round robin scheduler. It goes around thread table
@@ -22,15 +20,22 @@ const uint32_t LED_PIN = PICO_DEFAULT_LED_PIN;
 // thread for execution and schedules PendSV interrupt handler to be called.
 void SysTick_Handler()
 {
-    Thread_ID_t current_thread = os_get_current_thread();
-    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    struct OS_Thread_t * current_thread = os_get_current_thread();
+    struct OS_Thread_t * next_thread = (current_thread + 1);
+
+    if (next_thread >= &threads[THREADS_MAX])
+        next_thread = &threads[0];
+
     do {
-        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        if (next_thread->state == THREAD_STATE_READY)
         {
             os_schedule_context_switch(next_thread);
             return;
         }
-        next_thread = (next_thread + 1) % kernel_threads_count();
+        next_thread = (next_thread + 1);
+        if (next_thread >= &threads[THREADS_MAX])
+            next_thread = &threads[0];
+
     } while (next_thread != current_thread);
 }
 
@@ -83,15 +88,14 @@ int main(void)
     gpio_set_dir(LED_PIN, GPIO_OUT);
 
     // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
-    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
-    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
-    (void) thr2;
+    os_thread_create(&threads[0], thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    os_thread_create(&threads[1], thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
     
     // Setup systick
     kernel_tick_setup(500);
 
     // Start up the kernel
-    os_start(thr1);
+    os_start(&threads[0]);
 
     while (1);    
 }

--- a/examples/rp2040/main.cpp
+++ b/examples/rp2040/main.cpp
@@ -4,16 +4,14 @@
 #include CMSIS_device_header
 #include <stdint.h>
 
-#define THREADS_MAX         16
-
-uint8_t kernel_threads_count() { return THREADS_MAX; }
-
-struct OS_thread_t os_threads[THREADS_MAX];
-
-uint32_t thread1_stack[256];
-uint32_t thread2_stack[256];
-
 const uint32_t LED_PIN = PICO_DEFAULT_LED_PIN;
+
+uint8_t thread1_stack[256];
+uint8_t thread2_stack[256];
+
+#define THREADS_MAX     2
+
+struct OS_Thread_t threads[THREADS_MAX];
 
 /// Our example systick handler 
 // This implements round robin scheduler. It goes around thread table
@@ -22,15 +20,22 @@ const uint32_t LED_PIN = PICO_DEFAULT_LED_PIN;
 // thread for execution and schedules PendSV interrupt handler to be called.
 void SysTick_Handler()
 {
-    Thread_ID_t current_thread = os_get_current_thread();
-    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    struct OS_Thread_t * current_thread = os_get_current_thread();
+    struct OS_Thread_t * next_thread = (current_thread + 1);
+
+    if (next_thread >= &threads[THREADS_MAX])
+        next_thread = &threads[0];
+
     do {
-        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        if (next_thread->state == THREAD_STATE_READY)
         {
             os_schedule_context_switch(next_thread);
             return;
         }
-        next_thread = (next_thread + 1) % kernel_threads_count();
+        next_thread = (next_thread + 1);
+        if (next_thread >= &threads[THREADS_MAX])
+            next_thread = &threads[0];
+
     } while (next_thread != current_thread);
 }
 
@@ -83,15 +88,14 @@ int main(void)
     gpio_set_dir(LED_PIN, GPIO_OUT);
 
     // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
-    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
-    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
-    (void) thr2;
+    os_thread_create(&threads[0], thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    os_thread_create(&threads[1], thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
     
     // Setup systick
     kernel_tick_setup(500);
 
     // Start up the kernel
-    os_start(thr1);
+    os_start(&threads[0]);
 
     while (1);    
 }

--- a/examples/stm32f4/main.c
+++ b/examples/stm32f4/main.c
@@ -3,14 +3,12 @@
 #include CMSIS_device_header
 #include <stdint.h>
 
-#define THREADS_MAX         16
+uint8_t thread1_stack[256];
+uint8_t thread2_stack[256];
 
-uint8_t kernel_threads_count() { return THREADS_MAX; }
+#define THREADS_MAX     2
 
-struct OS_thread_t os_threads[THREADS_MAX];
-
-uint32_t thread1_stack[256];
-uint32_t thread2_stack[256];
+struct OS_Thread_t threads[THREADS_MAX];
 
 /// Our example systick handler 
 // This implements round robin scheduler. It goes around thread table
@@ -19,15 +17,22 @@ uint32_t thread2_stack[256];
 // thread for execution and schedules PendSV interrupt handler to be called.
 void SysTick_Handler()
 {
-    Thread_ID_t current_thread = os_get_current_thread();
-    Thread_ID_t next_thread = (current_thread + 1) % kernel_threads_count();
+    struct OS_Thread_t * current_thread = os_get_current_thread();
+    struct OS_Thread_t * next_thread = (current_thread + 1);
+
+    if (next_thread >= &threads[THREADS_MAX])
+        next_thread = &threads[0];
+
     do {
-        if (os_threads[next_thread].state == THREAD_STATE_READY)
+        if (next_thread->state == THREAD_STATE_READY)
         {
             os_schedule_context_switch(next_thread);
             return;
         }
-        next_thread = (next_thread + 1) % kernel_threads_count();
+        next_thread = (next_thread + 1);
+        if (next_thread >= &threads[THREADS_MAX])
+            next_thread = &threads[0];
+
     } while (next_thread != current_thread);
 }
 
@@ -47,6 +52,7 @@ void thread2_main(void * data)
     while (1) {
     }
 }
+
 
 /// Systic setup routine.
 // This routine takes systick interval in milliseconds and generates
@@ -74,15 +80,14 @@ void kernel_tick_setup(int interval_ms)
 int main(void)
 {
     // Create two threads, specify their entrypoints, their stacks, and use no entrypoint arguments
-    Thread_ID_t thr1 = os_thread_create(thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
-    Thread_ID_t thr2 = os_thread_create(thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
-    (void) thr2;
+    os_thread_create(&threads[0], thread1_main, (void *) 0, thread1_stack, sizeof(thread1_stack));
+    os_thread_create(&threads[1], thread2_main, (void *) 0, thread2_stack, sizeof(thread2_stack));
     
     // Setup systick
     kernel_tick_setup(500);
 
     // Start up the kernel
-    os_start(thr1);
+    os_start(&threads[0]);
 
     while (1);    
 }

--- a/src/kernel/api.h
+++ b/src/kernel/api.h
@@ -7,6 +7,18 @@
 extern "C" {
 #endif
 
+#ifndef NULL
+#define NULL ((void *) 0)
+#endif
+
+/** Error states returned by the kernel
+ */
+enum OS_Error {
+    OS_E_OK = 0,            // No error
+    OS_E_NULLPTR = 1,       // NULL pointer provided
+    OS_E_BUSY = 2,          // Thread already exists, cannot be created again
+};
+
 typedef uint8_t Thread_ID_t;
 
 /** List of states in which thread can be.
@@ -24,7 +36,7 @@ enum OS_ThreadState {
  *
  * This structure holds current status of the thread.
  */
-struct OS_thread_t {
+struct OS_Thread_t {
 	/** Value of SP. This is only valid if thread is in state different than
 	 * THREAD_STATE_RUNNING. Obviously it is undefined for empty thread slots
 	 * and slots which don't have stack allocated yet.
@@ -35,55 +47,42 @@ struct OS_thread_t {
 	enum OS_ThreadState state;
 };
 
-#define THREAD_TABLE_FULL 0xFF
-
 /** Opt for thread switch on current core.
  * Calling this function will prepare task switch. It will set up
  * some stuff needed and then schedule PendSV. You have to call this
  * function from supervisor mode. You can enter it either via timer
  * ISR, or implement it as SVC, which will yield.
- * @param next_thread_id ID of thread, which should be scheduled next
+ * @param next_thread address of thread struct for thread, which should be scheduled next
  */
-bool os_schedule_context_switch(Thread_ID_t next_thread_id);
+bool os_schedule_context_switch(struct OS_Thread_t * next_thread);
 
 /** Start operating system on current core.
  * This will leave supervisor mode into thread mode, switching into
  * thread-private stack. This function will automatically detect,
  * which core it is running on. You can call it multiple times on 
  * multiple cores.
- * @param startup_thread ID of thread which shall be ran
+ * @param startup_thread address of thread struct which shall be ran
  */
-void __attribute__((noreturn)) os_start(Thread_ID_t startup_thread);
+void __attribute__((noreturn)) os_start(struct OS_Thread_t * startup_thread);
 
 /** Get thread ID of currently running thread.
- * @returns ID of currently running thread
+ * @returns the address structure describing currently running thread 
  */
-Thread_ID_t os_get_current_thread();
+struct OS_Thread_t * os_get_current_thread();
 
 /** Create new thread.
  * Will populate thread table with new entry. Thread just created
  * is put into ready state, which means it can be immediately executed.
+ * @param thread address of thread structure, which has to be initialized
  * @param entrypoint address of the "main" function for this thread
  * @param data address of the data, which will be passed to the entrypoint function
  * @param stack base address of thread's stack
  * @param stack_size size of thread's stack
- * @returns ID of newly created thread, or special value THREAD_TABLE_FULL if there
- * is no more room for new threads.
+ * @returns @ref OS_Error status of the operation. OS_E_OK if thread was created,
+ * OS_E_NULLPTR if thread pointer is a NULL pointer, OS_E_BUSY if thread is already 
+ * created.
  */
-Thread_ID_t os_thread_create(void (* entrypoint)(void*), void * data, uint32_t * stack, uint32_t stack_size);
-
-/** Structure which holds information about existing threads
- * Implementer has to provide this variable having non-zero size
- */
-extern struct OS_thread_t os_threads[];
-
-/** Callback from kernel to calling code.
- * Implementer has to implement this function. It will provide kernel
- * with the information, how many threads there can be in os_threads
- * table allocated by the calling code.
- * @returns amount of slots available in os_threads array
- */
-extern uint8_t kernel_threads_count();
+int os_thread_create(struct OS_Thread_t * thread, void (* entrypoint)(void*), void * data, uint8_t * stack, uint32_t stack_size);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/kernel/api.h
+++ b/src/kernel/api.h
@@ -1,5 +1,15 @@
 #pragma once
 
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * C API declaration for nano RTOS.
+ *
+ * Copyright (c) 2022, Marek Koza (qyx@krtko.org)
+ * Copyright (c) 2023, Eduard Drusa
+ *
+ * All rights reserved.
+ */
+
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/src/kernel/arm_arch.h
+++ b/src/kernel/arm_arch.h
@@ -1,5 +1,14 @@
 #pragma once
 
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * AArch32 intrinsics and bare metal glue.
+ *
+ * Copyright (c) 2021-2023, Eduard Drusa
+ *
+ * All rights reserved.
+ */
+
 /* If we are running GCC, then try to include CMSIS RTE header to derive location
  * of the device file.
  */
@@ -16,6 +25,10 @@
 #ifdef CMSIS_device_header
 #include CMSIS_device_header
 
+// Here we wrap CMSIS objects into macros.
+// This way, if anyone wants to hardcode this, doesn't have to recreate whole CMSIS
+// stuff from scratch, if we need just one register and one flag here.
+// Actual symbol names are libopencm3-compatible
 #define SCB_ICSR SCB->ICSR
 #define SCB_ICSR_PENDSVSET (1 << SCB_ICSR_PENDSVSET_Pos)
 #define cortex_enable_interrupts() __disable_irq()

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,3 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * C implementation of nano RTOS kernel.
+ * Some concepts borrowed from https://github.com/zyp/laks.
+ *
+ * Copyright (c) 2022, Marek Koza (qyx@krtko.org)
+ * Copyright (c) 2023, Eduard Drusa
+ * Copyright (c) 2013, Vegard Storheil Eriksen
+ *
+ * All rights reserved.
+ */
+
 #include "kernel.h"
 #include "api.h"
 #include <stdint.h>

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -1,5 +1,17 @@
 #pragma once
 
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Internal structures of nano RTOS.
+ * Some concepts borrowed from https://github.com/zyp/laks.
+ *
+ * Copyright (c) 2022, Marek Koza (qyx@krtko.org)
+ * Copyright (c) 2023, Eduard Drusa
+ * Copyright (c) 2013, Vegard Storheil Eriksen
+ *
+ * All rights reserved.
+ */
+
 #include "api.h"
 #include "arm_arch.h"
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -12,8 +12,11 @@
 
 #include <stdint.h>
 
-/** Alias thread ID */
-typedef uint8_t Thread_ID_t;
+/* The current thread stack frame / saved context on the stack. */
+struct Frame {
+    uint32_t r4, r5, r6, r7, r8, r9, r10, r11;
+    uint32_t r0, r1, r2, r3, r12, lr, pc, psr;
+};
 
 /** Structure holding current scheduling state of CPU.
  *
@@ -22,9 +25,7 @@ typedef uint8_t Thread_ID_t;
  * CPUs.
  */
 struct OS_core_state_t {
-	Thread_ID_t thread_prev;
-	Thread_ID_t thread_current;
-	Thread_ID_t thread_next;
+	struct OS_Thread_t * thread_prev;
+	struct OS_Thread_t * thread_current;
+	struct OS_Thread_t * thread_next;
 };
-
-extern struct OS_thread_t os_threads[];


### PR DESCRIPTION
C version of the API is changed so that it doesn't enforce any particular way how threads descriptors are organized in the memory. This simplifies both real-time schedulers, which can now do whatever they want with their priority queues and also thread descriptor extension as struct OS_Thread_t now can be simply wrapped by some user-defined structure.

Examples updated  to reflect this new API.